### PR TITLE
New xml error

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
 	<!-- loads jQuery -->
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 	<!-- loads mapbox-gl -->
-	<script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.2.1/mapbox-gl.js"></script>
+	<script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.16.0/mapbox-gl.js"></script>
 	<style>
         body { margin:0; padding:0; }
 		#map { position:absolute; top:50px; bottom:40px; width:100%; }
@@ -80,6 +80,7 @@ var map = new mapboxgl.Map({
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
     <script src="/mina.github.io/js/bootstrap.min.js"></script>
+	<script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.2.1/mapbox-gl.js"></script>
     <script src="/mina.github.io/leaflet-omnivore-master/leaflet-omnivore.js"></script>
 	<script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.2.2/mapbox-gl.css"></script>
 	<script src="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js"></script>


### PR DESCRIPTION
Revert to previous mapbox-gl script. 

mapbox-gl.js:7 XMLHttpRequest cannot load mapbox://styles/dngupta/cipa4hz260012bknlg4pqs9ov. Cross origin requests are only supported for protocol schemes: http, data, chrome, chrome-extension, https, chrome-extension-resource.exports.getJSON @ mapbox-gl.js:7module.exports @ mapbox-gl.js:6(anonymous function) @ (index):61
mapbox-gl.css:1 Uncaught SyntaxError: Unexpected token .

